### PR TITLE
Add functions. Get directory for tuned profiles in /etc.

### DIFF
--- a/basic/lib.sh
+++ b/basic/lib.sh
@@ -234,6 +234,33 @@ tunedDisableSystemdRateLimitingEnd()
 	return 0
 }
 
+
+true <<'=cut'
+=pod
+
+=head2 tunedGetProfilesBaseDir
+
+Get current profile directory.
+
+    tunedGetProfilesBaseDir
+
+=over
+
+=back
+
+=cut
+
+tunedGetProfileDir()
+{
+    BASEPATH="/etc/tuned/"
+    if [ -d "/etc/tuned/profiles" ]; then
+        BASEPATH="/etc/tuned/profiles/"
+    fi
+
+    echo "${BASEPATH}"
+}
+
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   Execution
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Since rhel10, tuned have new path for profiles so
tests need to be updated.