### PR TITLE
Add Packit configuration

### DIFF
--- a/.packit.yml
+++ b/.packit.yml
@@ -1,0 +1,11 @@
+downstream_package_name: tuned
+jobs:
+- job: tests
+  trigger: commit
+  branch: master
+  skip_build: true
+  fmf_url: https://github.com/redhat-performance/tuned
+  targets:
+    - fedora-all
+    - centos-stream-9-x86_64
+    - centos-stream-10-x86_64


### PR DESCRIPTION
This PR should enable executing tests after each commit to the master branch. We cannot test pull requests because there is no way to tell Packit and Testing Farm to include the beakerlib library from the pull request.

Before this is merged, the Packit service should be set up according to https://packit.dev/docs/guide:
1. First enable Packit for this repo via https://github.com/apps/packit-as-a-service.
2. The maintainer of this repo should then get an email to verify themselves using their Fedora account (FAS).

Also note that the tests are executed according to TMT plans in https://github.com/redhat-performance/tuned, but the tested TuneD RPM is the one present in the tested distribution (as opposed to the Packit CI executed in PRs of our upstream TuneD repo, where the RPM is built from source of the PR).